### PR TITLE
Don't try to generate param reports without the requisite args

### DIFF
--- a/src/lib/comparison.js
+++ b/src/lib/comparison.js
@@ -34,6 +34,11 @@ class ParamReport {
 }
 
 function _generateParamReports(atomDocArgs, inspectorArgs) {
+  if (!atomDocArgs || !inspectorArgs) {
+    // Cannot generate reports if these are missing
+    return [];
+  }
+
   const paramReports = atomDocArgs.map((atomDocArg, index) => {
     const inspectorArg = inspectorArgs[index];
     const paramReport = new ParamReport(atomDocArg, inspectorArg);


### PR DESCRIPTION
Really not sure why this was failing in the first place, but this fixes the error here https://travis-ci.org/Topdoc/postcss-topdoc/builds/532908077#L516.

I don't know if this has other consequences and don't have the time to investigate, but perhaps this will help @GarthDB figure it out.